### PR TITLE
chat-spaceデータベース設計

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,24 +1,40 @@
-# README
+# DB設計
+--------------------------------------------------------
+## userテーブル
+|column|Type|Options|
+|------|----|------|
+|name|text|null: false,|
+|email|text|null: false, foreign_key: true|
+|password|text|null: false, foreign_key: true|
+### Association
+- has_many :group, througth :groups_users
+- has_many :comment
 
-This README would normally document whatever steps are necessary to get the
-application up and running.
 
-Things you may want to cover:
+## groups_usersテーブル
+|Column|Type|Options|
+|------|----|-------|
+|user_id|integer|null: false, foreign_key: true|
+|group_id|integer|null: false, foreign_key: true|
+### Association
+- belongs_to :group
+- belongs_to :user
 
-* Ruby version
 
-* System dependencies
+## groupテーブル
+|Column|Type|Options|
+|------|----|-------|
+|name|text|null: false|
+### Association
+- has_many :user, througth :groups_users
+- has_many :comment
 
-* Configuration
-
-* Database creation
-
-* Database initialization
-
-* How to run the test suite
-
-* Services (job queues, cache servers, search engines, etc.)
-
-* Deployment instructions
-
-* ...
+## commentテーブル
+|Column|Type|Options|
+|------|----|-------|
+|message|text|null: false|
+|user_id|integer|null: false, foreign_key: true|
+|group_id|integer|null: false, foreign_key: true|
+### Association
+- belongs_to: user
+- belongs_to: group

--- a/README.md
+++ b/README.md
@@ -3,13 +3,12 @@
 ## userテーブル
 |column|Type|Options|
 |------|----|------|
-|name|text|null: false|
-|email|text|null: false|
-|password|text|null: false|
+|name|text|null: false,|
+|email|text|null: false, foreign_key: true|
+|password|text|null: false, foreign_key: true|
 ### Association
-- has_many :group, througth: :groups_users
-- has_many :groups_users
-- has_many :message
+- has_many :group, througth :groups_users
+- has_many :comment
 
 
 ## groups_usersテーブル
@@ -28,10 +27,9 @@
 |name|text|null: false|
 ### Association
 - has_many :user, througth :groups_users
-- has_many :message
-- has_many :groups_users
+- has_many :comment
 
-## messageテーブル
+## commentテーブル
 |Column|Type|Options|
 |------|----|-------|
 |message|text|null: false|

--- a/README.md
+++ b/README.md
@@ -3,20 +3,20 @@
 ## userテーブル
 |column|Type|Options|
 |------|----|------|
-|name|text|null: false|
-|email|text|null: false|
-|password|text|null: false|
+|name|string|null: false, index: true|
+|email|string|null: false|
+|password|string|null: false|
 ### Association
-- has_many :group, througth: :groups_users
+- has_many :groups, througth: :groups_users
 - has_many :groups_users
-- has_many :message
+- has_many :messages
 
 
 ## groups_usersテーブル
 |Column|Type|Options|
 |------|----|-------|
-|user_id|integer|null: false, foreign_key: true|
-|group_id|integer|null: false, foreign_key: true|
+|user|references|null: false, foreign_key: true|
+|group|references|null: false, foreign_key: true|
 ### Association
 - belongs_to :group
 - belongs_to :user
@@ -25,18 +25,19 @@
 ## groupテーブル
 |Column|Type|Options|
 |------|----|-------|
-|name|text|null: false|
+|name|string|null: false|
 ### Association
-- has_many :user, througth :groups_users
-- has_many :message
+- has_many :users, througth :groups_users
+- has_many :messages
 - has_many :groups_users
 
 ## messageテーブル
 |Column|Type|Options|
 |------|----|-------|
-|message|text|null: false|
-|user_id|integer|null: false, foreign_key: true|
-|group_id|integer|null: false, foreign_key: true|
+|message|text||
+|images|string||
+|user|references|null: false, foreign_key: true|
+|group|references|null: false, foreign_key: true|
 ### Association
 - belongs_to: user
 - belongs_to: group

--- a/README.md
+++ b/README.md
@@ -3,12 +3,13 @@
 ## userテーブル
 |column|Type|Options|
 |------|----|------|
-|name|text|null: false,|
-|email|text|null: false, foreign_key: true|
-|password|text|null: false, foreign_key: true|
+|name|text|null: false|
+|email|text|null: false|
+|password|text|null: false|
 ### Association
-- has_many :group, througth :groups_users
-- has_many :comment
+- has_many :group, througth: :groups_users
+- has_many :groups_users
+- has_many :message
 
 
 ## groups_usersテーブル
@@ -27,9 +28,10 @@
 |name|text|null: false|
 ### Association
 - has_many :user, througth :groups_users
-- has_many :comment
+- has_many :message
+- has_many :groups_users
 
-## commentテーブル
+## messageテーブル
 |Column|Type|Options|
 |------|----|-------|
 |message|text|null: false|


### PR DESCRIPTION
# What
READMEにてchat-spaceのDB設計を行いました。
テーブルは
・userテーブル
・groupテーブル
・groups_usersテーブル
・commentテーブル
の四つです。

# Why
ユーザーの登録、グループの作成、メッセージの入力の三つのデータ入力のところから、
この四つのテーブルが必要だと考えました。
idやtimestompがいるのかと思いましたが、どうやら必要ないようなので削除しました。

よろしくお願いします。